### PR TITLE
minor tweaks: lcd and acoustic pins

### DIFF
--- a/Sensors/Light/read_light.py
+++ b/Sensors/Light/read_light.py
@@ -34,7 +34,7 @@ class read_light:
         print('full: ',str(full),' ir: ',str(ir))
         if lcdF == 1:
             lcd.clear()      # Sleep for 1 sec
-            lcd.putstr('full: '+str(full)+'\nir: '+str(ir)+' lux: '+str(round(lux,2)))
+            lcd.putstr(str(round(lux,1))+' lux\n('+str(full)+','+str(ir)+')')
 
     # -------------------------------------------------------------------------------
     # Get continuous light measurements
@@ -56,7 +56,7 @@ class read_light:
             print("\n")         # Print a line of space between temp readings so it is easier to read
             if lcdF ==1:
                 lcd.clear()      # Sleep for 1 sec
-                lcd.putstr("# "+str(sample_num)+' full: '+str(full)+'\nir: '+str(ir)+' lux: '+str(round(lux,2)))
+                lcd.putstr("# "+str(sample_num)+': '+str(round(lux,1))+' lux\n('+str(full)+','+str(ir)+')')
             sleep_ms(max(sleep_microsec-pause_microsec,0))      # Wait 5 sec, before repeating the loop and taking another reading
             sample_num+=1       # Increment the sample number for each reading
         if lcdF == 1:

--- a/Sensors/platform_defs.py
+++ b/Sensors/platform_defs.py
@@ -24,8 +24,8 @@ if platform.find('Feather STM32F405 with STM32F405RG')>-1:  # Board-specific def
     p_I2Cscl_lbl='SCL'
     p_I2Csda_lbl='SDA'
     #pin definitions for hcsr04/jsn sensors
-    p_hcsr_trig = 'D10'
-    p_hcsr_echo = 'D9'
+    p_hcsr_trig = 'D12'
+    p_hcsr_echo = 'D11'
     # speed of sound in air (default) for hcsr04
     hcsr_c = 343
 


### PR DESCRIPTION
- Changed the lcd printout for the light sensor to read: #### lux \n (XX,XX) with full and ir being in parentheses instead of explicitly labeled. This is due to the number of characters needed when saturated.
- Changed the platform definitions for the acoustic pins on the stm to D11 and D12 so that all 3 sensors in the kits can be used at once (original defs had temp and acoustic on the same pins, communication was fine for the temperature sensor but 4.7k resistor would be issue for hcsr04)