### PR TITLE
HC05 display tweaks

### DIFF
--- a/Sensors/SetUp/PYB_defs.py
+++ b/Sensors/SetUp/PYB_defs.py
@@ -3,7 +3,7 @@
 # Board-specific definitions: Pyboard v1.1
 
 print('Loading definitions for PYBv1.1')
-from machine import Pin, I2C
+from machine import Pin, I2C, Timer
 from pyb import Switch, UART
 
 board='PBDv1.1'
@@ -14,13 +14,17 @@ p_pwr3 = Pin('X3', Pin.OUT,value=0)  # Pin X3 is power supplied to the GPS, V+
 p_pwr4 = Pin('X4', Pin.OUT,value=0)  # Pin X4 is power supplied to the GPS, V+
 p_DS18B20 = Pin('X20', Pin.IN)  # Pin X20 is the data pin for DS18B20 temperature sensors
 uartGPS= UART(4, 9600)
+uartGPS.init(9600, bits=8, parity=None, stop=1,timeout_char=5)
 uartAQ= UART(3, 9600)
 uartAQ.init(9600, bits=8, parity=None, stop=1)
+uartBT= UART(6, 9600)
+uartBT.init(9600, bits=8, parity=None, stop=1)
 #p_batt=14
 #p_sens=4
 # Define default I2C pins
 p_I2Cscl_lbl='X9'
 p_I2Csda_lbl='X10'
+i2c_num=1
 # I2C without an ID currently reverts to SoftI2C; use hardware I2C(1)
 # instead, which has the specified pinouts
 #i2c = I2C(scl=Pin(p_I2Cscl_lbl),sda=Pin(p_I2Csda_lbl))

--- a/Sensors/SetUp/default_params.py
+++ b/Sensors/SetUp/default_params.py
@@ -96,6 +96,7 @@ params={'setup_dir':'SetUp',
         'sample_max':10,
         'sample_interval':10,
         'display_interval':0,
-        'verbosity':15
+        'verbosity':15,
+        'bt_flag':0
 }
 

--- a/Sensors/SetUp/platform_defs.py
+++ b/Sensors/SetUp/platform_defs.py
@@ -1,6 +1,6 @@
 #  Definitions of platform-specific pins and commands.
 #
-#  Currently supported boards are: STM32f405 Feather, ESP8266 Huzzah Feather/Breakout Board, Pyboard v1.1
+#  Currently supported boards are: STM32f405 Feather, ESP32 Huzzah Feather, Pyboard v1.1
 
 # Detect platform via uos command
 from uos import uname
@@ -8,7 +8,10 @@ sys_info = uname()
 print(sys_info)
 platform=sys_info[4]
 
+# Default values (may be altered for specific platforms)
+uartBT = False # This is the uart for HC05 bluetooth module, by default off
 
+# Platform-specific definitions
 if platform.find('Feather STM32F405 with STM32F405RG')>-1:  # Board-specific definitions: STM32f405 Feather
     print('Platform is STM32 Feather')
     from SetUp.FeatherSTM32F405_defs import *
@@ -26,9 +29,3 @@ elif platform.find('ESP32 module with ESP32')>-1:  # Board-specific definitions:
     from SetUp.FeatherESP32_defs import *
 
 
-'''
-(sysname='pyboard', nodename='pyboard', release='1.13.0', version='v1.13-53-gc20075929-dirty on 2020-09-21', machine='Adafruit Feather STM32F405 with STM32F405RG')
-(sysname='esp8266', nodename='esp8266', release='2.2.0-dev(9422289)', version='v1.9.4-701-g10bddc5c2 on 2019-01-17', machine='ESP module with ESP8266')
-(sysname='pyboard', nodename='pyboard', release='1.13.0', version='v1.13 on 2020-09-02', machine='PYBv1.1 with STM32F405RG')
-(sysname='esp32', nodename='esp32', release='1.17.0', version='v1.17 on 2021-09-02', machine='ESP32 module with ESP32')
-'''

--- a/Sensors/SetUp/user_params.py
+++ b/Sensors/SetUp/user_params.py
@@ -3,16 +3,16 @@
 # This script sets user-specified parameters. Default parameters are set in default_params.py.
 #
 params={'sensor_list':{'distance':0,
-                       'temperature':0,
+                       'temperature':1,
                        'light':0,
                        'UIV':0,
                        'color':0,
                        'GPS':0,
                        'AQI':0,
-                       'CO2':1,
+                       'CO2':0,
                        'voltage':0,
                        'pressure':0,
-                       'exttime':1},
+                       'exttime':0},
         'sensor_log_directory':'Data',
         'sensor_log_flags':{ 'distance':1,
                        'temperature':1,
@@ -30,6 +30,7 @@ params={'sensor_list':{'distance':0,
         'sample_max':4,
         'sample_interval':120,
         'display_interval':3,
-        'verbosity':14
+        'verbosity':14,
+        'bt_flag':1
 }
 


### PR DESCRIPTION
3This PR adds transmitting displayed strings through an HC05 bluetooth transmitter, via uartBT (so far defined only for the pyboard).

Use of the HC05 is turned on/off by bt_flag, now added to default_params (where it is defined off) and optionally turned back on in user_params.

This PR also fixes a bug in which display strings accumulate indefinitely if no LCD is present. Display strings are now popped according to the specified timer, whether the LCD and/or HC05 are present or not.