### PR TITLE
Add unique_id and instr_name to logfile names

### DIFF
--- a/Sensors/SetUp/default_params.py
+++ b/Sensors/SetUp/default_params.py
@@ -110,6 +110,8 @@ params={'setup_dir':'SetUp',
         'bt_log_prefix':'BTtelem',
         'bt_rec_interval':250,
         'bt_start_str':'|||>',
-        'bt_end_str':'<|||'
+        'bt_end_str':'<|||',
+        'IDchars':4,
+        'instr_name':None
 }
 

--- a/Sensors/SetUp/sensor_utils.py
+++ b/Sensors/SetUp/sensor_utils.py
@@ -374,8 +374,6 @@ class Sampler:
         vrb_print('Final list of active sensors is: ',new_pars['active_sensors'],level='base')
         vrb_print('Updating pars with: ',new_pars,level='high')
         self.pars.update(new_pars)
-    
-
             
 
     def start_log_files(self):
@@ -394,8 +392,18 @@ class Sampler:
             nfile+=1
             timestamp=tuple([list(self.rtc.datetime())[d] for d in [0,1,2,4,5,6]])
             timestamp_str=self.pars['timestamp_format'] % timestamp
+            #logfilename=self.pars['sensor_log_directory']+'/'+timestamp_str+'_'+ \
+            #    str(nfile) + '_' + self.pars['sensor_log_prefixes'][sensr]+'.csv'
             logfilename=self.pars['sensor_log_directory']+'/'+timestamp_str+'_'+ \
-                str(nfile) + '_' + self.pars['sensor_log_prefixes'][sensr]+'.csv'
+                str(nfile) + '_'
+            if self.pars['IDchars']>0: # Add characters from unique ID
+                from ubinascii import hexlify
+                from machine import unique_id
+                sensor_id=str(hexlify(unique_id()))[2:-1]
+                logfilename += sensor_id[:self.pars['IDchars']]+'_'
+            if self.pars['instr_name'] is not None:
+                logfilename += self.pars['instr_name']+'_'
+            logfilename += self.pars['sensor_log_prefixes'][sensr]+'.csv'
             vrb_print('creating log file: ',logfilename,level='low')
             logfile=open(logfilename,'w')
             sensor_log_format=self.pars['sensor_log_formats'][sensr]
@@ -435,7 +443,17 @@ class Sampler:
             timestamp=tuple([list(self.rtc.datetime())[d] for d in [0,1,2,4,5,6]])
             timestamp_str=self.pars['timestamp_format'] % timestamp
             logfilename=self.pars['sensor_log_directory']+'/'+timestamp_str+'_'+ \
-                str(nfile) + '_' + self.pars['bt_log_prefix']+'.csv'
+                str(nfile) + '_'
+            if self.pars['IDchars']>0: # Add characters from unique ID
+                from ubinascii import hexlify
+                from machine import unique_id
+                sensor_id=str(hexlify(unique_id()))[2:-1]
+                logfilename += sensor_id[:self.pars['IDchars']]+'_'
+            if self.pars['instr_name'] is not None:
+                logfilename += self.pars['instr_name']+'_'
+            logfilename+= self.pars['bt_log_prefix']+'.csv'
+            #logfilename=self.pars['sensor_log_directory']+'/'+timestamp_str+'_'+ \
+            #    str(nfile) + '_' + self.pars['bt_log_prefix']+'.csv'
             vrb_print('creating log file: ',logfilename,level='low')
             logfile=open(logfilename,'w')
             logfile.write('HC-05 bluetooth-telemetered display data\n')

--- a/Sensors/SetUp/user_params.py
+++ b/Sensors/SetUp/user_params.py
@@ -2,9 +2,9 @@
 #
 # This script sets user-specified parameters. Default parameters are set in default_params.py.
 #
-params={'sensor_list':{'distance':0,
+params={'sensor_list':{'distance':1,
                        'temperature':1,
-                       'light':0,
+                       'light':1,
                        'UIV':0,
                        'color':0,
                        'humidity':0,
@@ -34,6 +34,8 @@ params={'sensor_list':{'distance':0,
         'display_interval':8,
         'output_level':'base', # Output options: 'base', 'low','med', 'high', or number 1-15
         'bt_send':0,
-        'bt_rec':0
+        'bt_rec':0,
+        'IDchars':4,
+        'instr_name':'Danny'
 }
 


### PR DESCRIPTION
This PR merges the additions to log file names, which add the first few characters (# determined in params) of the unique microcontroller ID and an optional group or individual name. The goal is to be able to track the sources of log files pooled into a common directory.