### PR TITLE
Freq

### DIFF
--- a/Sensors/SetUp/FeatherSTM32F405_defs.py
+++ b/Sensors/SetUp/FeatherSTM32F405_defs.py
@@ -9,7 +9,7 @@ from machine import Pin, I2C, SoftI2C, Timer, freq, idle
 
 # Set CPU frequency (note this is persisent across reboots)
 #CPUfreq =168000000 # default (max) freq setting
-CPUfreq =42000000   # reduced freq to save power
+CPUfreq = 42000000   # reduced freq to save power
 freq(CPUfreq)
 vrb_print('Using CPU frequency ',freq(),level='low')
 

--- a/Sensors/SetUp/FeatherSTM32F405_defs.py
+++ b/Sensors/SetUp/FeatherSTM32F405_defs.py
@@ -5,7 +5,13 @@ from SetUp.verbosity import vrb_print
 vrb_print('Loading definitions for STM32F405 Feather',level='low')
 
 from pyb import UART # Use pyb UART bc machine.UART clashes with DS18B20s
-from machine import Pin, I2C, SoftI2C, Timer
+from machine import Pin, I2C, SoftI2C, Timer, freq, idle
+
+# Set CPU frequency (note this is persisent across reboots)
+#CPUfreq =168000000 # default (max) freq setting
+CPUfreq =42000000   # reduced freq to save power
+freq(CPUfreq)
+vrb_print('Using CPU frequency ',freq(),level='low')
 
 board='STM32feather'
 p_pwr1 = Pin('D9', Pin.OUT,value=1)  # Pin 9 is power supplied to the DS18B20, V+

--- a/Sensors/SetUp/sensor_utils.py
+++ b/Sensors/SetUp/sensor_utils.py
@@ -7,7 +7,7 @@ try: # The ESP32 build seems to lack sync, so skip if unavailable
 except:
     pass
 from os import listdir
-from machine import Pin, Timer
+from machine import Pin, Timer, idle
 
 from SetUp.verbosity import vrb_print,vrb_setlevel
 
@@ -303,7 +303,9 @@ class Sampler:
                     sync()
                 except:
                     pass
-                                   
+        # Go into idle state to save power (until next timer or IRQ event)
+        idle()
+        
     def sample_loop_timer(self):
         # Method to initiate a timer that calls sample_check (a non-blocking
         # alternative to sampler_loop. sample_check also executes a non-

--- a/Sensors/SetUp/user_params.py
+++ b/Sensors/SetUp/user_params.py
@@ -2,9 +2,9 @@
 #
 # This script sets user-specified parameters. Default parameters are set in default_params.py.
 #
-params={'sensor_list':{'distance':0,
+params={'sensor_list':{'distance':1,
                        'temperature':1,
-                       'light':0,
+                       'light':1,
                        'UIV':0,
                        'color':0,
                        'humidity':0,
@@ -13,7 +13,7 @@ params={'sensor_list':{'distance':0,
                        'CO2':0,
                        'voltage':0,
                        'pressure':0,
-                       'exttime':0},
+                       'exttime':1},
         'sensor_log_directory':'Data',
         'sensor_log_flags':{ 'distance':0,
                        'temperature':0,


### PR DESCRIPTION
Tweaks to reduce power consumption: reduce CPU clock (in STM32F405 only), and idle() between calls to sample_check.

These don't seem to have a large effect, but the costs also seem small.

Note the clock change is persistent across reboots.